### PR TITLE
Add github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install libnetfilter-queue-dev
+      run: sudo apt-get install libnetfilter-queue-dev
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Upgrade pip
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install package
+      run: |
+        pip install .
+    - name: Import
+      run: |
+        python -c "import netfilterqueue"
+    - name: Check cython
+      run: |
+        pip install cython
+        python setup.py build_ext --force


### PR DESCRIPTION
Thought this might be useful to have some free CI checks on the codebase. This just checks the package builds and can be imported.

See the last run on my fork https://github.com/johnteslade/python-netfilterqueue/runs/1248803795 - see #60 for the fix so it compiles on all versions.
