### PR TITLE
Update README with `python-dev-is-python3`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Before installing, ensure you have:
 
 On Debian or Ubuntu, install these files with::
 
-    apt-get install build-essential python-dev libnetfilter-queue-dev
+    apt-get install build-essential python-dev-is-python3 libnetfilter-queue-dev
 
 From PyPI
 ---------


### PR DESCRIPTION
Trying installing `python-dev` raises `Package 'python-dev' has no installation candidate` error, because it's outdated. `python-dev-is-python3` replaces it. I've tested installing netfilterqueue with poetry after that and it worked fine.